### PR TITLE
Revert "universal8890: overlay: Enable connected MAC randomization"

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -123,9 +123,6 @@
     <!-- Boolean indicating whether the wifi chipset has background scan support -->
     <bool translatable="false" name="config_wifi_background_scan_support">true</bool>
 
-    <!-- True if the firmware supports connected MAC randomization -->
-    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
-
     <!-- True if the firmware supports p2p MAC randomization -->
     <bool name="config_wifi_p2p_mac_randomization_supported">false</bool>
 


### PR DESCRIPTION
This reverts commit 8d43aff0a0b18e64c18b54b8fda9489c2bbc3df1.

 * Sadly it breaks WiFi-Direct

Change-Id: I48f93886129752a0c406a6c6131ca29901e84041