### PR TITLE
Revert "universal8890: Enable link Probing"

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -126,9 +126,6 @@
     <!-- True if the firmware supports p2p MAC randomization -->
     <bool name="config_wifi_p2p_mac_randomization_supported">false</bool>
 
-    <!-- True if the firmware supports Wi-Fi link probing -->
-    <bool name="config_wifi_link_probing_supported">true</bool>
-
     <!-- Idle Receive current for wifi radio. 0 by default-->
     <integer translatable="false" name="config_wifi_idle_receive_cur_ma">1</integer>
 


### PR DESCRIPTION
This reverts commit 763b4879663712a5cc685b5cf1cd8c30eaef031f.

 * Sadly this causes a kernel panic when connecting\disconnecting to
   WiFi-Direct devices

Change-Id: Ia9c0d3728527e0bba9857cda3ade735ad29d31e2