### PR TITLE
Revert "universal8890: allow hal_nfc_default search permission to nfc…

### DIFF
--- a/sepolicy/hal_nfc_default.te
+++ b/sepolicy/hal_nfc_default.te
@@ -6,6 +6,5 @@ allow hal_nfc_default nfc_data_file:file getattr;
 allow hal_nfc_default nfc_data_file:dir write;
 allow hal_nfc_default nfc_data_file:dir add_name;
 allow hal_nfc_default nfc_data_file:file create;
-allow hal_nfc_default nfc_vendor_data_file:dir search;
 
 set_prop(hal_nfc_default, vendor_nfc_prop)


### PR DESCRIPTION
…_vendor_data_file"

This reverts commit fb0c2f4b7fb8785a182824cc3cb8e9f3858c4cfd.

Reason for revert: incorrectly backported from lineage-18.1

Change-Id: Idf724ff1c12103a6df9de3535e1109c2ce6d0612